### PR TITLE
g++ added to pkg deps in server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.9-slim
 
 # install pkg deps
-RUN apt update && apt install -y ffmpeg libmagic-dev gcc
+RUN apt update && apt install -y ffmpeg libmagic-dev gcc g++
 
 # install py deps
 COPY ./requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
Build issue with gcc:
When running docker compose up during build we get the following error
`gcc: error trying to exec 'cc1plus': execvp: No such file or directory`
After a quick research it seems to be a similar issue to this [https://stackoverflow.com/questions/39455741/gcc-error-trying-to-exec-cc1plus-execvp-no-such-file-or-directory](https://stackoverflow.com/questions/39455741/gcc-error-trying-to-exec-cc1plus-execvp-no-such-file-or-directory)
After adding g++ to the pkg deps for the server it fixed the build error