### PR TITLE
updates required to upgrade yt-dlp: python, deno

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,14 +1,19 @@
 # PRODUCTION DOCKERFILE
-FROM python:3.9-slim
+FROM python:3.10-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # install pkg deps
-RUN apt update && apt install -y ffmpeg libmagic-dev gcc g++
+RUN apt-get update && apt-get install -y ffmpeg libmagic-dev gcc g++
+
+# bring in Deno javascript runtime for yt-dlp
+COPY --from=denoland/deno:bin-2.6.3 /deno /usr/local/bin/deno
 
 # install py deps
 COPY ./requirements.txt /tmp/requirements.txt
-RUN pip3  --disable-pip-version-check --no-cache-dir install -r /tmp/requirements.txt
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/requirements.txt
 RUN rm -v /tmp/requirements.txt
-RUN pip3 install -U yt-dlp
+RUN pip3 --disable-pip-version-check --no-cache-dir install -U yt-dlp
 
 # make the nonroot user
 RUN useradd user -m -s /usr/sbin/nologin


### PR DESCRIPTION
Seeing issues connecting with Google's servers with the installed yt-dlp with the same error as #27. The bug highlighted there was happening with all videos.

yt-dlp was the culprit and not at all this application, as Google broke compatibility with yt-dlp earlier this year, please see https://github.com/yt-dlp/yt-dlp/issues/15012

To upgrade yt-dlp, a couple things were required:

1.) Python 3.9 had to be upgraded to at least Python 3.10. Ref: https://github.com/yt-dlp/yt-dlp/releases/tag/2025.10.22
2.) Deno JavaScript runtime had to be brought into the container. Ref: https://github.com/yt-dlp/yt-dlp/issues/15012

Also adjusted the Dockerfile slightly for less pip and apt warnings at build time.
Works just like normal after that. Cheers!